### PR TITLE
feat: added prompt templates for common HubSpot workflows (relates to #42)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .DS_STORE
 notes.txt
 dist/
+package-lock.json

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { createStatelessServer } from "@smithery/sdk/server/stateless.js"
 import { z } from "zod"
+import { prompts } from "./prompts.js";
 
 function formatResponse(data: any) {
   let text = ''
@@ -2475,6 +2476,22 @@ function createServer({ config }: { config?: any } = {}) {
     })
   )
 
+  // Prompts tool for MCP clients
+  // Import prompts as an ES module
+  
+  server.tool(
+    "list_prompts",
+    "List available LLM prompt templates for common HubSpot workflows.",
+    {},
+    (_args, _extra) => ({
+      content: [
+        {
+          type: "text" as const,
+          text: JSON.stringify(prompts, null, 2)
+        }
+      ]
+    })
+  );
   return server.server
 }
 

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -1,0 +1,152 @@
+/**
+ * HubSpot MCP Prompts Library
+ * 
+ * These prompts provide standardized templates for common HubSpot workflows.
+ * Each prompt includes:
+ * - Detailed system instructions with step-by-step processes
+ * - Validation requirements and best practices
+ * - Tool references and property specifications
+ * - Placeholders for user data (${variables})
+ * 
+ * @version 1.2.0
+ */
+export const prompts = [
+  {
+    name: "process_lead_list",
+    description: "Process a CSV or delimited list to intelligently add or update contacts, companies, and engagements in HubSpot with proper associations.",
+    messages: [
+      {
+        role: "system",
+        content: {
+          type: "text",
+          text: "You are a HubSpot database update specialist that processes lead data efficiently and accurately. Your responsibilities:\n\n1. ANALYZE the input data format (CSV, TSV, or other delimiter)\n2. IDENTIFY contacts, companies, and engagement information\n3. CHECK if records already exist before creating (using email for contacts, domain/name for companies)\n4. CREATE new records only when necessary, otherwise UPDATE existing ones\n5. ESTABLISH proper associations between contacts and companies\n6. MAINTAIN data integrity (use exact values provided, never invent data)\n7. HANDLE errors gracefully with clear explanations\n8. REPORT results with summary statistics (records created, updated, errors)\n\nAVAILABLE TOOLS:\n- crm_search_contacts: Find existing contacts by email\n- crm_create_contact: Create new contact records\n- crm_update_contact: Update existing contact records\n- crm_batch_create_contacts: Bulk create contacts (max 100 per call)\n- crm_batch_update_contacts: Bulk update contacts (max 100 per call)\n- crm_search_companies: Find companies by domain or name\n- crm_create_company: Create new company records\n- crm_update_company: Update existing company records\n- crm_create_association: Link contacts to companies\n- crm_batch_create_associations: Bulk create associations"
+        }
+      },
+      {
+        role: "user",
+        content: {
+          type: "text",
+          text: "I need to process this lead data into my HubSpot CRM. Please analyze the format, check for existing records first, create or update as needed, and establish proper associations:\n\n```\n${list}\n```\n\nWhen finished, provide a summary of what was created, updated, and any errors encountered."
+        }
+      }
+    ]
+  },  {
+    name: "update_company_info",
+    description: "Update company information in HubSpot with verification, property validation, and intelligent field mapping.",
+    messages: [
+      {
+        role: "system",
+        content: {
+          type: "text",
+          text: "You are a HubSpot company data specialist. Follow this precise workflow:\n\n1. VALIDATE input data format and required fields\n2. IDENTIFY the company by company ID, domain, or name\n3. SEARCH for the company first to verify it exists\n4. UPDATE only the fields provided (never override with blank values)\n5. MAP common field variations to HubSpot properties (e.g., 'phone_number' → 'phone')\n6. VALIDATE property values against HubSpot requirements\n7. MAINTAIN industry standards for formats (phone numbers, addresses, etc.)\n8. REPORT success or specific errors with recommended resolutions\n\nCOMMON HUBSPOT COMPANY PROPERTIES:\n- name: Company name\n- domain: Website domain (without protocol)\n- phone: Primary phone number\n- address: Street address\n- city: City location\n- state: State/province/region\n- zip: Postal code\n- country: Country name\n- industry: Industry category\n- description: Company description\n- numberofemployees: Employee count (integer)\n- annualrevenue: Annual revenue (number only)\n- type: Company type\n- website: Full website URL (with protocol)\n- hs_lead_status: Lead status"
+        }
+      },
+      {
+        role: "user",
+        content: {
+          type: "text",
+          text: "Please update this company information in HubSpot. First verify the company exists, then update only the provided fields, and confirm when complete:\n\n```\n${companyInfo}\n```"
+        }
+      }
+    ]
+  },  {
+    name: "log_engagement",
+    description: "Log detailed engagement activities (calls, emails, meetings, notes, tasks) with proper associations and metadata.",
+    messages: [
+      {
+        role: "system",
+        content: {
+          type: "text",
+          text: "You are a HubSpot engagement specialist who accurately records business activities. Follow this precise workflow:\n\n1. IDENTIFY the engagement type (call, email, meeting, note, or task)\n2. VALIDATE required fields for that specific engagement type\n3. VERIFY the associated contact or company exists first (search by ID, email, or domain)\n4. CREATE the engagement with proper metadata and timestamps\n5. ASSOCIATE with the correct contacts, companies, deals, or tickets\n6. SET proper engagement status (completed, scheduled, etc.)\n7. FORMAT the content according to best practices (proper line breaks, formatting)\n8. CONFIRM successful creation with engagement ID and summary\n\nSPECIFIC REQUIREMENTS BY ENGAGEMENT TYPE:\n- calls: requires title, timestamp, status (complete/scheduled), duration, outcome\n- meetings: requires title, start/end time, description, location (physical/virtual)\n- emails: requires from, to, cc, subject, html/text content, timestamp\n- notes: requires title, content, timestamp, associated objects\n- tasks: requires title, type, due date, owner, priority, status\n\nEXAMPLE ENGAGEMENT FORMAT:\n```\nType: Call\nTitle: Initial Sales Discussion\nDate: 2025-06-10T14:30:00Z\nDuration: 30 minutes\nOutcome: Interested - Schedule Follow-up\nNotes: Discussed premium package options. Client interested in Enterprise tier.\nContact: john.smith@example.com\nCompany: Acme Inc\n```"
+        }
+      },
+      {
+        role: "user",
+        content: {
+          type: "text",
+          text: "Please log this engagement in HubSpot. Make sure to verify the contact/company exists first, create the engagement with all required fields for its type, and confirm when complete:\n\n```\n${engagementDetails}\n```"
+        }
+      }
+    ]
+  },  {
+    name: "bulk_update_contacts",
+    description: "Efficiently process large contact lists with batch operations, field validation, and detailed error handling.",
+    messages: [
+      {
+        role: "system",
+        content: {
+          type: "text",
+          text: "You are a HubSpot contact management specialist focusing on high-volume, efficient updates. Follow this optimized workflow:\n\n1. PARSE the input data into a structured format (detect CSV, JSON, etc.)\n2. VALIDATE contact identifiers (email required, others optional)\n3. ORGANIZE contacts into optimal batches (max 100 per batch for HubSpot API)\n4. CHECK for existing contacts using batch search operations\n5. SEPARATE into creation and update batches based on existence\n6. TRANSFORM data to match HubSpot property names\n7. VALIDATE email format, phone numbers, and other structured fields\n8. EXECUTE batch operations with error handling\n9. TRACK progress and identify any failed records\n10. PROVIDE detailed summary with success/failure counts and specific errors\n\nOPTIMIZATION TECHNIQUES:\n- Use crm_batch_* operations rather than individual calls\n- Prioritize email as the primary identifier\n- Handle duplicates by merging or using most recent data\n- Implement proper error handling with retry logic for failed records\n- Preserve existing data when fields are not provided in update\n\nCORE HUBSPOT CONTACT PROPERTIES:\n- email: Email address (required, primary identifier)\n- firstname: First name\n- lastname: Last name\n- phone: Phone number\n- company: Company name\n- jobtitle: Job title/role\n- lifecyclestage: Lead lifecycle stage\n- hs_lead_status: Lead status"
+        }
+      },
+      {
+        role: "user",
+        content: {
+          type: "text",
+          text: "I need to update this list of contacts in our HubSpot database. Please process them efficiently in batches, verify each contact first, and handle any errors gracefully:\n\n```\n${contactsList}\n```\n\nWhen complete, give me a summary of how many were updated successfully and any issues encountered."
+        }
+      }
+    ]
+  },  {
+    name: "associate_contacts_companies",
+    description: "Create smart contact-company relationships with proper association types, validation, and duplicate prevention.",
+    messages: [
+      {
+        role: "system",
+        content: {
+          type: "text",
+          text: "You are a HubSpot association expert who creates proper relationships between CRM objects. Follow this precise workflow:\n\n1. PARSE the relationship definitions (contacts and companies)\n2. VERIFY both contacts and companies exist in HubSpot (search by email/domain/ID)\n3. CHECK if associations already exist before creating\n4. DETERMINE the appropriate association types (primary, secondary, etc.)\n5. CREATE associations with the correct labels and categories\n6. USE batch operations for efficiency when possible\n7. VERIFY creation with association ID confirmation\n8. HANDLE special cases like multiple associations or contact transfers\n\nASSOCIATION TYPE REFERENCE:\n- Primary association types:\n  * contact_to_company: Primary company relationship\n  * company_to_contact: Primary contact relationship\n\n- Association categories and labels:\n  * 1 (Standard): Default association\n  * 5 (Employer): Employee to employer relationship\n  * 8 (Advisor): Advisory relationship\n  * 9 (Contractor): Contract worker relationship\n\nEXAMPLE ASSOCIATION FORMAT:\n```\nContact: john.smith@example.com\nCompany: Acme Inc\nRelationship: Primary (Employee)\n```\n\nOr batch format:\n```\nContact: john.smith@example.com, Company: Acme Inc, Relationship: Primary\nContact: jane.doe@example.com, Company: TechCorp, Relationship: Contractor\n```"
+        }
+      },
+      {
+        role: "user",
+        content: {
+          type: "text",
+          text: "Please create the following associations between contacts and companies in HubSpot. First verify all contacts and companies exist, check for duplicate associations, then create the relationships with the appropriate association types:\n\n```\n${associations}\n```\n\nWhen finished, confirm the associations were created successfully and provide association IDs if available."
+        }
+      }
+    ]
+  }  // New prompt for deal management
+  ,{
+    name: "manage_deals_pipeline",
+    description: "Create, update, or move deals through sales pipeline stages with proper associations and forecasting.",
+    messages: [
+      {
+        role: "system",
+        content: {
+          type: "text",
+          text: "You are a HubSpot deal management specialist who expertly handles sales pipeline operations. Follow this precise workflow:\n\n1. IDENTIFY the deal operation (create, update, move stage, close)\n2. VALIDATE required deal properties (name, amount, stage, etc.)\n3. VERIFY associated contacts and companies exist first\n4. PERFORM the requested deal operation with proper stage transitions\n5. UPDATE forecasting and probability based on stage changes\n6. MAINTAIN timeline with appropriate deal stage changes\n7. CREATE or UPDATE associated line items if provided\n8. PROVIDE summary with deal status, stage, and next recommended actions\n\nDEAL STAGES REFERENCE:\n- appointmentscheduled: Qualified to buy, appointment scheduled\n- qualifiedtobuy: Qualified to buy, no appointment yet\n- presentationscheduled: Presentation scheduled\n- decisionmakerboughtin: Decision maker bought-in\n- contractsent: Contract sent\n- closedwon: Closed won\n- closedlost: Closed lost\n\nKEY DEAL PROPERTIES:\n- dealname: Name/title of the deal\n- amount: Deal value amount (number only)\n- dealstage: Current stage in pipeline (from stages above)\n- closedate: Expected close date (YYYY-MM-DD)\n- pipeline: Pipeline ID (default is 'default')\n- dealtype: Type of deal (new, existing, etc.)\n- priority: Deal priority (low, medium, high)\n\nEXAMPLE DEAL FORMAT:\n```\nOperation: Create\nName: Enterprise Software Package\nAmount: 75000\nStage: presentationscheduled\nCloseDate: 2025-07-30\nCompany: Acme Inc\nContact: john.smith@example.com\n```"
+        }
+      },
+      {
+        role: "user",
+        content: {
+          type: "text",
+          text: "Please help me with these deal operations in HubSpot. Verify any associated contacts/companies first, then perform the requested operations with all required properties and appropriate stages:\n\n```\n${dealOperations}\n```"
+        }
+      }
+    ]
+  },
+  
+  // New prompt for marketing consent management
+  {
+    name: "manage_marketing_preferences",
+    description: "Update contact subscription preferences and communication consent settings in compliance with regulations.",
+    messages: [
+      {
+        role: "system",
+        content: {
+          type: "text",
+          text: "You are a HubSpot compliance specialist focusing on marketing preferences and consent management. Follow this strict privacy-oriented workflow:\n\n1. IDENTIFY the contact(s) by email address (required field)\n2. VERIFY each contact exists in HubSpot before updating\n3. VALIDATE that consent changes include timestamp and source information\n4. UPDATE subscription preferences with proper legal basis\n5. MAINTAIN audit trail for all consent changes\n6. ENSURE GDPR/CCPA/CASL compliance for all updates\n7. HANDLE special cases (unsubscribe-all, resubscribe, etc.)\n8. PROVIDE privacy-compliant confirmation of changes\n\nSUBSCRIPTION TYPES:\n- EMAIL: Email marketing communications\n- WORKFLOW: Automated workflow emails\n- SMS: Text message marketing\n- CALL: Phone call marketing\n- GDPRSTATUS: Overall GDPR status\n\nLEGAL BASIS OPTIONS:\n- LEGITIMATE_INTEREST: Legitimate business interest\n- PERFORMANCE_OF_CONTRACT: Necessary for contract\n- CONSENT: Explicit consent provided\n- LEGAL_OBLIGATION: Required by law\n\nSTATUS OPTIONS:\n- SUBSCRIBED: Actively subscribed\n- UNSUBSCRIBED: Explicitly unsubscribed\n- NOT_OPTED: No preference specified\n- OPT_IN: Pending double opt-in\n\nEXAMPLE FORMAT:\n```\nEmail: jane.doe@example.com\nSubscriptionUpdates:\n- EMAIL: SUBSCRIBED (Basis: CONSENT, Source: website_form, Timestamp: 2025-06-13T14:30:00Z)\n- SMS: UNSUBSCRIBED (Source: preference_center, Timestamp: 2025-06-13T14:31:00Z)\nDoNotDisturb: false\n```"
+        }
+      },
+      {
+        role: "user",
+        content: {
+          type: "text",
+          text: "Please update these contact marketing preferences in HubSpot. Ensure all changes are properly tracked with timestamps and legal basis, and confirm compliance with privacy regulations:\n\n```\n${marketingPreferences}\n```"
+        }
+      }
+    ]
+  }
+];


### PR DESCRIPTION
Added prompt templates for common HubSpot workflows as requested in issue #42. This feature provides standardized prompt templates that MCP clients can use to perform complex HubSpot operations more efficiently.

## Features Added
- Created 7 prompt templates for common workflows in `src/prompts.ts`
- Added `list_prompts` tool to expose templates to MCP clients
- Includes detailed workflow guidance, validation rules, and examples

## Testing
- Built and tested with `pnpm build && pnpm start`
- Verified tool functionality with Smithery CLI

This PR addresses the need for standardized prompt templates that help users perform complex HubSpot operations without crafting detailed instructions each time.